### PR TITLE
Fix: Add namespace to Router class

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Core;
+
 class Router {
     protected static $routes = [];
 

--- a/index.php
+++ b/index.php
@@ -1,4 +1,6 @@
 <?php
 
 require_once './core/init.php';
+use Core\Router;
+
 Router::dispatch($_GET['url'] ?? '/');


### PR DESCRIPTION
The Router class was missing the Core namespace, which caused a 'Class not found' error. This commit adds the namespace and the corresponding `use` statement in `index.php` to resolve the issue.