### PR TITLE
Fix: Update User model to use Core\Model

### DIFF
--- a/app/plugins/Auth/models/User.php
+++ b/app/plugins/Auth/models/User.php
@@ -1,6 +1,8 @@
  
 <?php
 
+use Core\Model;
+
 class User extends Model {
     protected $table = 'msk_users';
 

--- a/core/init.php
+++ b/core/init.php
@@ -2,6 +2,7 @@
 session_start();
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/Env.php';
 
 $pluginManager = new Core\PluginManager(__DIR__ . '/../app/plugins');
 $pluginManager->discoverPlugins();


### PR DESCRIPTION
The User model in the Auth plugin was not using the fully qualified name for the Model class, which caused a 'Class not found' error. I've added the necessary `use` statement to resolve the issue.