### PR TITLE
Fix: Use fully qualified name for env function

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -110,7 +110,7 @@ class Router {
     }
 
     protected static function debug($text){
-        if (env('DEBUG') === 'true') {
+        if (\env('DEBUG') === 'true') {
             echo "<pre style='color: white; background:#222; padding:8px 12px; font-size:13px; margin-bottom:6px; border-left: 4px solid white;'>$text</pre><br/>";
         }
     }


### PR DESCRIPTION
The `env()` function was not being called with its fully qualified name in the `Router` class, which caused a 'Call to undefined function' error. This commit changes the call to `\env()` to resolve the issue.